### PR TITLE
Merge remote-tracking branch 'upstream/main' into wasm32-wasi

### DIFF
--- a/.swiftci/5_10_ubuntu2204
+++ b/.swiftci/5_10_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    swift_version_tag = "5.10-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/5_7_ubuntu2204
+++ b/.swiftci/5_7_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    swift_version_tag = "5.7-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/5_8_ubuntu2204
+++ b/.swiftci/5_8_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    swift_version_tag = "5.8-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/5_9_ubuntu2204
+++ b/.swiftci/5_9_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    swift_version_tag = "5.9-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_6_0_macos
+++ b/.swiftci/nightly_6_0_macos
@@ -1,0 +1,5 @@
+macOSSwiftPackageJob {
+    swift_version = "6.0"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_6_0_ubuntu2204
+++ b/.swiftci/nightly_6_0_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    nightly_docker_tag = "nightly-6.0-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_main_macos
+++ b/.swiftci/nightly_main_macos
@@ -1,0 +1,5 @@
+macOSSwiftPackageJob {
+    swift_version = "main"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_main_ubuntu2204
+++ b/.swiftci/nightly_main_ubuntu2204
@@ -1,0 +1,5 @@
+LinuxSwiftPackageJob {
+    nightly_docker_tag = "nightly-jammy"
+    repo = "swift-format"
+    branch = "main"
+}

--- a/.swiftci/nightly_main_windows
+++ b/.swiftci/nightly_main_windows
@@ -1,0 +1,7 @@
+WindowsSwiftPackageWithDockerImageJob {
+    docker_image = "swiftlang/swift:nightly-windowsservercore-1809"
+    repo = "swift-format"
+    branch = "main"
+    sub_dir = "swift-format"
+    label = "windows-server-2019"
+}

--- a/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
+++ b/Sources/SwiftFormat/PrettyPrint/TokenStreamCreator.swift
@@ -1799,6 +1799,17 @@ fileprivate final class TokenStreamCreator: SyntaxVisitor {
     return .visitChildren
   }
 
+  override func visit(_ node: OriginallyDefinedInAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    after(node.colon.lastToken(viewMode: .sourceAccurate), tokens: .break(.same, size: 1))
+    after(node.comma.lastToken(viewMode: .sourceAccurate), tokens: .break(.same, size: 1))
+      return .visitChildren
+  }
+
+  override func visit(_ node: DocumentationAttributeArgumentSyntax) -> SyntaxVisitorContinueKind {
+    after(node.colon, tokens: .break(.same, size: 1))
+    return .visitChildren
+  }
+
   override func visit(_ node: AvailabilityLabeledArgumentSyntax) -> SyntaxVisitorContinueKind {
     before(node.label, tokens: .open)
 

--- a/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
+++ b/Tests/SwiftFormatTests/PrettyPrint/AttributeTests.swift
@@ -26,6 +26,40 @@ final class AttributeTests: PrettyPrintTestCase {
     assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
   }
 
+  func testAttributeParamSpacingInOriginallyDefinedIn() {
+    let input =
+      """
+      @_originallyDefinedIn( module  :"SwiftUI" , iOS 10.0  )
+      func f() {}
+      """
+
+    let expected =
+      """
+      @_originallyDefinedIn(module: "SwiftUI", iOS 10.0)
+      func f() {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
+  func testAttributeParamSpacingInDocVisibility() {
+    let input =
+      """
+      @_documentation(  visibility   :private )
+      func f() {}
+      """
+
+    let expected =
+      """
+      @_documentation(visibility: private)
+      func f() {}
+
+      """
+
+    assertPrettyPrintEqual(input: input, expected: expected, linelength: 60)
+  }
+
   func testAttributeBinPackedWrapping() {
     let input =
       """


### PR DESCRIPTION
- **Fix @_originallyDefinedIn argument spacing**
- **Fix incorrect spacing when pretty-printing @_documentation**
- **Add post merge Swift CI support for swift-format**
- **Fix typo in the .swiftci windows testing file**
