### PR TITLE
Cherry-pick "fix: make `format -i` to work again" to 5.10

### DIFF
--- a/Sources/swift-format/Frontend/FormatFrontend.swift
+++ b/Sources/swift-format/Frontend/FormatFrontend.swift
@@ -59,7 +59,11 @@ class FormatFrontend: Frontend {
 
         if buffer != source {
           let bufferData = buffer.data(using: .utf8)!  // Conversion to UTF-8 cannot fail
-          try bufferData.write(to: url, options: .atomic)
+          #if !os(WASI)
+            try bufferData.write(to: url, options: .atomic)
+          #else
+            try bufferData.write(to: url)
+          #endif
         }
       } else {
         try formatter.format(


### PR DESCRIPTION
cherry-picks 1e0635d3eb0aa4a813ffe765ea2dd10805a271bf to wasm32-wasi-release/5.10
