### PR TITLE
ci: bump Swift SDK to swift-wasm-6.0-SNAPSHOT-2024-06-14-a

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.0-jammy@sha256:1c27fb3516eac72f45e9bc6f9dbbdb470de1f78ec582602df8080c69e8b3abbb
+    container: swiftlang/swift:nightly-6.0-jammy@sha256:f0539cdca206be225924aee0c2e00d8901ddecda4e3f7e79c2b312573c0606e1
     env:
       STACK_SIZE: 524288
     steps:
@@ -15,7 +15,7 @@ jobs:
       - name: Install tools
         run: apt-get update && apt-get install --no-install-recommends -y wabt binaryen
       - run: swift --version
-      - run: swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0-SNAPSHOT-2024-06-09-a/swift-wasm-6.0-SNAPSHOT-2024-06-09-a-ubuntu22.04_x86_64.artifactbundle.zip
+      - run: swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0-SNAPSHOT-2024-06-14-a/swift-wasm-6.0-SNAPSHOT-2024-06-14-a-wasm32-unknown-wasi.artifactbundle.zip
       - name: Build
         run: |
           swift build --product swift-format --swift-sdk wasm32-unknown-wasi -c release -Xlinker -z -Xlinker stack-size=$STACK_SIZE
@@ -28,7 +28,7 @@ jobs:
           path: swift-format.wasm
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.0-jammy@sha256:1c27fb3516eac72f45e9bc6f9dbbdb470de1f78ec582602df8080c69e8b3abbb
+    container: swiftlang/swift:nightly-6.0-jammy@sha256:f0539cdca206be225924aee0c2e00d8901ddecda4e3f7e79c2b312573c0606e1
     env:
       STACK_SIZE: 4194304
     steps:
@@ -36,6 +36,6 @@ jobs:
       - uses: bytecodealliance/actions/wasmtime/setup@v1
       - run: swift --version
       - run: wasmtime -V
-      - run: swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0-SNAPSHOT-2024-06-09-a/swift-wasm-6.0-SNAPSHOT-2024-06-09-a-ubuntu22.04_x86_64.artifactbundle.zip
+      - run: swift sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0-SNAPSHOT-2024-06-14-a/swift-wasm-6.0-SNAPSHOT-2024-06-14-a-wasm32-unknown-wasi.artifactbundle.zip
       - run: swift build -c release --build-tests --swift-sdk wasm32-unknown-wasi -Xlinker -z -Xlinker stack-size=$STACK_SIZE
       - run: wasmtime --dir / --wasm max-wasm-stack=$STACK_SIZE .build/release/swift-formatPackageTests.wasm


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.0-SNAPSHOT-2024-06-14-a