### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-30-a

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -6,6 +6,7 @@ on:
     branches: ["wasm32-wasi"]
 env:
   SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-11-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-11-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 4bd7ce303c22de1728bfc667c024a43e3d6f916b3598d229311e65760ce9006e
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   build:
@@ -18,7 +19,7 @@ jobs:
       - name: Install tools
         run: apt-get update && apt-get install --no-install-recommends -y wabt binaryen
       - run: swift --version
-      - run: swift sdk install $SWIFT_SDK_URL
+      - run: swift sdk install $SWIFT_SDK_URL --checksum $SWIFT_SDK_CHECKSUM
       - name: Build
         run: |
           swift build --product swift-format --swift-sdk $TARGET_TRIPLE -c release -Xlinker -z -Xlinker stack-size=$STACK_SIZE
@@ -39,6 +40,6 @@ jobs:
       - uses: bytecodealliance/actions/wasmtime/setup@v1
       - run: swift --version
       - run: wasmtime -V
-      - run: swift sdk install $SWIFT_SDK_URL
+      - run: swift sdk install $SWIFT_SDK_URL --checksum $SWIFT_SDK_CHECKSUM
       - run: swift build -c release --build-tests --swift-sdk $TARGET_TRIPLE -Xlinker -z -Xlinker stack-size=$STACK_SIZE
       - run: wasmtime --dir / --wasm max-wasm-stack=$STACK_SIZE .build/release/swift-formatPackageTests.wasm

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-26-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-26-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 38000eba7324918e1853562dbe4ae80759764d2d31fe3c48c75de815b5b31aae
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-27-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-27-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 6cae1db37d6a975089f5c5b49179bafe7c611c5b92aa93ba03be85928bd9384c
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:d8b718734c89da257fc04638893cd243dfdcccdb0ebfe4fe1cc59b8912766753
+    container: swiftlang/swift:nightly-main-jammy@sha256:29a112d0e2391a07e3cfd810e2e655394c7454983967466f7f8e7b393e7d04c8
     env:
       STACK_SIZE: 524288
     steps:
@@ -32,7 +32,7 @@ jobs:
           path: swift-format.wasm
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:d8b718734c89da257fc04638893cd243dfdcccdb0ebfe4fe1cc59b8912766753
+    container: swiftlang/swift:nightly-main-jammy@sha256:29a112d0e2391a07e3cfd810e2e655394c7454983967466f7f8e7b393e7d04c8
     env:
       STACK_SIZE: 4194304
     steps:

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-27-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-27-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 6cae1db37d6a975089f5c5b49179bafe7c611c5b92aa93ba03be85928bd9384c
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-30-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-30-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: e2865f6c1b948c355c858671408cafb6b7a16c2a5d36d64b0176bd183f8cceff
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:29a112d0e2391a07e3cfd810e2e655394c7454983967466f7f8e7b393e7d04c8
+    container: swiftlang/swift:nightly-main-jammy@sha256:f402bf92ef7612b0467562b563e432a0b97614508502cfeb6585e4b024941bb8
     env:
       STACK_SIZE: 524288
     steps:
@@ -32,7 +32,7 @@ jobs:
           path: swift-format.wasm
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:29a112d0e2391a07e3cfd810e2e655394c7454983967466f7f8e7b393e7d04c8
+    container: swiftlang/swift:nightly-main-jammy@sha256:f402bf92ef7612b0467562b563e432a0b97614508502cfeb6585e4b024941bb8
     env:
       STACK_SIZE: 4194304
     steps:

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-11-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-11-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 4bd7ce303c22de1728bfc667c024a43e3d6f916b3598d229311e65760ce9006e
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-23-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-23-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 933ae72a762d7fa386dc78c36968d0ea3bd3100fc418ebed490c6434fa6f14d2
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:cde40eb65aa0bd36c68fde8ba32f21d154f8a56685cae6bff9e2db520537a67e
+    container: swiftlang/swift:nightly-main-jammy@sha256:b0374b2d3b3c993b8a771096000ae782b130c2726f84d6792ffa8982918f92a2
     env:
       STACK_SIZE: 524288
     steps:
@@ -32,7 +32,7 @@ jobs:
           path: swift-format.wasm
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:cde40eb65aa0bd36c68fde8ba32f21d154f8a56685cae6bff9e2db520537a67e
+    container: swiftlang/swift:nightly-main-jammy@sha256:b0374b2d3b3c993b8a771096000ae782b130c2726f84d6792ffa8982918f92a2
     env:
       STACK_SIZE: 4194304
     steps:

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-07-16-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-07-16-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-11-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-11-a-wasm32-unknown-wasi.artifactbundle.zip
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:49f484ac6cf144cdb816d3de7c487e9926d97aa92ec195e8878ba42e4121f3f4
+    container: swiftlang/swift:nightly-main-jammy@sha256:cde40eb65aa0bd36c68fde8ba32f21d154f8a56685cae6bff9e2db520537a67e
     env:
       STACK_SIZE: 524288
     steps:
@@ -31,7 +31,7 @@ jobs:
           path: swift-format.wasm
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:49f484ac6cf144cdb816d3de7c487e9926d97aa92ec195e8878ba42e4121f3f4
+    container: swiftlang/swift:nightly-main-jammy@sha256:cde40eb65aa0bd36c68fde8ba32f21d154f8a56685cae6bff9e2db520537a67e
     env:
       STACK_SIZE: 4194304
     steps:

--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-23-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-23-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 933ae72a762d7fa386dc78c36968d0ea3bd3100fc418ebed490c6434fa6f14d2
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-26-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-26-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 38000eba7324918e1853562dbe4ae80759764d2d31fe3c48c75de815b5b31aae
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:b0374b2d3b3c993b8a771096000ae782b130c2726f84d6792ffa8982918f92a2
+    container: swiftlang/swift:nightly-main-jammy@sha256:d8b718734c89da257fc04638893cd243dfdcccdb0ebfe4fe1cc59b8912766753
     env:
       STACK_SIZE: 524288
     steps:
@@ -32,7 +32,7 @@ jobs:
           path: swift-format.wasm
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:b0374b2d3b3c993b8a771096000ae782b130c2726f84d6792ffa8982918f92a2
+    container: swiftlang/swift:nightly-main-jammy@sha256:d8b718734c89da257fc04638893cd243dfdcccdb0ebfe4fe1cc59b8912766753
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-08-30-a