### PR TITLE
ci: bump Swift SDK to swift-wasm-6.0-SNAPSHOT-2024-09-18-a

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.0"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0-SNAPSHOT-2024-08-30-a/swift-wasm-6.0-SNAPSHOT-2024-08-30-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 49627585d38eefb8afee2fbf71b0e72ac229fb0e9d6a0a42488c0662797541cb
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0-SNAPSHOT-2024-09-18-a/swift-wasm-6.0-SNAPSHOT-2024-09-18-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 32daa52eeaa591af71f4ce9b8e4936ed6e4dfc503be6faad44e6decdb556b4c7
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.0-jammy@sha256:f6bc1bd8a10c5595ce63515c974ff2c6a8ce73e888085e601830a4770aaf6dbd
+    container: swiftlang/swift:nightly-6.0-jammy@sha256:4470306cf882455918b21e36d87b098e044ffeaecf8649da66efbb3769f12ff2
     env:
       STACK_SIZE: 524288
     steps:
@@ -32,7 +32,7 @@ jobs:
           path: swift-format.wasm
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.0-jammy@sha256:f6bc1bd8a10c5595ce63515c974ff2c6a8ce73e888085e601830a4770aaf6dbd
+    container: swiftlang/swift:nightly-6.0-jammy@sha256:4470306cf882455918b21e36d87b098e044ffeaecf8649da66efbb3769f12ff2
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.0-SNAPSHOT-2024-09-18-a