### PR TITLE
ci: pin wasmtime version to 24.0.0

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
+        with:
+          version: "24.0.0"
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install $SWIFT_SDK_URL --checksum $SWIFT_SDK_CHECKSUM


### PR DESCRIPTION
I've used the latest wasmtime in the CI, but that sometimes broke the CI, so I'm going to pin its version.