### PR TITLE
ci: bump wasmtime to 25.0.1

### DIFF
--- a/.github/workflows/Swift.yml
+++ b/.github/workflows/Swift.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "24.0.0"
+          version: "25.0.1"
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install $SWIFT_SDK_URL --checksum $SWIFT_SDK_CHECKSUM


### PR DESCRIPTION
- https://github.com/bytecodealliance/wasmtime/releases/tag/v25.0.0
- https://github.com/bytecodealliance/wasmtime/releases/tag/v25.0.1