### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,13 +5,13 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-26-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-26-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 34c53bac6f41502f26056fd14bbf4757eca2cb93fdab089dd25449bc17cbc3c8
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 229cd9d3b0ed582c7ef7c3064888ad78764e4743b5a770df92554a94513f53fb
   TARGET_TRIPLE: wasm32-unknown-wasi
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:61db5d799a789a4808061fc35b85098959f09a80a4e47136a58a52469e8cd2bb
+    container: swiftlang/swift:nightly-main-jammy@sha256:83dc66efd857459460a64c9475cf399751db1dcfce4fd656b8195e299893d5f7
     env:
       STACK_SIZE: 524288
     steps:
@@ -32,7 +32,7 @@ jobs:
           path: swift-format.wasm
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:61db5d799a789a4808061fc35b85098959f09a80a4e47136a58a52469e8cd2bb
+    container: swiftlang/swift:nightly-main-jammy@sha256:83dc66efd857459460a64c9475cf399751db1dcfce4fd656b8195e299893d5f7
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-15-a