### PR TITLE
ci: remove `-all` from `wasm-opt` and add a job to test swift-format.wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -8,6 +8,7 @@ env:
   SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0.2-RELEASE/swift-wasm-6.0.2-RELEASE-wasm32-unknown-wasi.artifactbundle.zip
   SWIFT_SDK_CHECKSUM: 6ffedb055cb9956395d9f435d03d53ebe9f6a8d45106b979d1b7f53358e1dcb4
   TARGET_TRIPLE: wasm32-unknown-wasi
+  WASMTIME_VESRION: 26.0.1
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,12 +25,27 @@ jobs:
         run: |
           swift build --product swift-format --swift-sdk $TARGET_TRIPLE -c release -Xlinker -z -Xlinker stack-size=$STACK_SIZE
           wasm-strip .build/release/swift-format.wasm
-          wasm-opt -Oz -all .build/release/swift-format.wasm -o swift-format.wasm
-      - name: Upload artifacts
+          wasm-opt -Oz --enable-bulk-memory --enable-sign-ext .build/release/swift-format.wasm -o swift-format.wasm
+      - name: Upload swift-format.wasm
         uses: actions/upload-artifact@v4
         with:
           name: swift-format.wasm
           path: swift-format.wasm
+  test-binary:
+    needs: build
+    runs-on: ubuntu-latest
+    container: swiftlang/swift:nightly-main-jammy@sha256:53838abb7c3e750b6327d339e27cac5aa4ee40e6ec545346748625ec0f4fe90b
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bytecodealliance/actions/wasmtime/setup@v1
+        with:
+          version: ${{ env.WASMTIME_VERSION }}
+      - name: Download swift-format.wasm
+        uses: actions/download-artifact@v4
+        with:
+          name: swift-format.wasm
+      - run: wasmtime --dir . swift-format.wasm --version
+      - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
     container: swift:6.0.2-jammy
@@ -39,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
-          version: "26.0.1"
+          version: ${{ env.WASMTIME_VERSION }}
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install $SWIFT_SDK_URL --checksum $SWIFT_SDK_CHECKSUM


### PR DESCRIPTION
I cherry-picked #140 to wasm32-wasi-release/6.0 for the future release of 6.0.x.