### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-15-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-31-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-10-31-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: e42546397786ea6eaec2d9c07f9118a6f3428784cf3df3840a369f19700c1a69
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-15-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-15-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 58c187073a753ee45bfcba42bda6aecbdb6f7c9ca98a349b956c9e592d93ff5f
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 26.0.1
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:53838abb7c3e750b6327d339e27cac5aa4ee40e6ec545346748625ec0f4fe90b
+    container: swiftlang/swift:nightly-main-jammy@sha256:c2dc288c275c18f46ef281967081591d1fdc196afd0569bf45da246723478480
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:53838abb7c3e750b6327d339e27cac5aa4ee40e6ec545346748625ec0f4fe90b
+    container: swiftlang/swift:nightly-main-jammy@sha256:c2dc288c275c18f46ef281967081591d1fdc196afd0569bf45da246723478480
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:53838abb7c3e750b6327d339e27cac5aa4ee40e6ec545346748625ec0f4fe90b
+    container: swiftlang/swift:nightly-main-jammy@sha256:c2dc288c275c18f46ef281967081591d1fdc196afd0569bf45da246723478480
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-15-a