### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-19-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-15-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-15-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 58c187073a753ee45bfcba42bda6aecbdb6f7c9ca98a349b956c9e592d93ff5f
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-19-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-19-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: e9baa22676162c8175ca757c3c67b8b2947b9edab95704c2a3898572445f8c7e
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 26.0.1
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:c2dc288c275c18f46ef281967081591d1fdc196afd0569bf45da246723478480
+    container: swiftlang/swift:nightly-main-jammy@sha256:43546dd7abb89b21fca08e5c420a28af6eb7b1edbc0394f6fda8ca33a30da750
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:c2dc288c275c18f46ef281967081591d1fdc196afd0569bf45da246723478480
+    container: swiftlang/swift:nightly-main-jammy@sha256:43546dd7abb89b21fca08e5c420a28af6eb7b1edbc0394f6fda8ca33a30da750
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:c2dc288c275c18f46ef281967081591d1fdc196afd0569bf45da246723478480
+    container: swiftlang/swift:nightly-main-jammy@sha256:43546dd7abb89b21fca08e5c420a28af6eb7b1edbc0394f6fda8ca33a30da750
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-19-a