### PR TITLE
ci: bump wasmtime to 27.0.0

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -8,7 +8,7 @@ env:
   SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-15-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-15-a-wasm32-unknown-wasi.artifactbundle.zip
   SWIFT_SDK_CHECKSUM: 58c187073a753ee45bfcba42bda6aecbdb6f7c9ca98a349b956c9e592d93ff5f
   TARGET_TRIPLE: wasm32-unknown-wasi
-  WASMTIME_VESRION: 26.0.1
+  WASMTIME_VESRION: 27.0.0
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v27.0.0