### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-20-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-19-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-19-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: e9baa22676162c8175ca757c3c67b8b2947b9edab95704c2a3898572445f8c7e
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-20-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-20-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 1f51846c6e615bba7f9b6d702a7e607f1ee91bea7b0b101020573b8018017297
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 27.0.0
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:43546dd7abb89b21fca08e5c420a28af6eb7b1edbc0394f6fda8ca33a30da750
+    container: swiftlang/swift:nightly-main-jammy@sha256:5f4ecca618db3910a727abc1577ed38db0fe0a75e8b30b56e50fdab9f76989ff
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:43546dd7abb89b21fca08e5c420a28af6eb7b1edbc0394f6fda8ca33a30da750
+    container: swiftlang/swift:nightly-main-jammy@sha256:5f4ecca618db3910a727abc1577ed38db0fe0a75e8b30b56e50fdab9f76989ff
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:43546dd7abb89b21fca08e5c420a28af6eb7b1edbc0394f6fda8ca33a30da750
+    container: swiftlang/swift:nightly-main-jammy@sha256:5f4ecca618db3910a727abc1577ed38db0fe0a75e8b30b56e50fdab9f76989ff
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-20-a