### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-29-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-24-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-24-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 2c601b5da42659cf54176df4c0c5f48b0da8b0ad11647531143e5aec058d45c1
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-29-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-29-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 772d979b13ba3f3f4329044c8080885ebbd6ce05f7c06e9ecfcc90ee5bf8ad48
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 27.0.0
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:0441267bc90fba42e25c608386845b81a0a0fcd2789c0efe84e2eff50aab8614
+    container: swiftlang/swift:nightly-main-jammy@sha256:8ecfcd63f1c127b58fef579ad4e5e48308feea1fadb8a1629146c31bc8d8364e
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:0441267bc90fba42e25c608386845b81a0a0fcd2789c0efe84e2eff50aab8614
+    container: swiftlang/swift:nightly-main-jammy@sha256:8ecfcd63f1c127b58fef579ad4e5e48308feea1fadb8a1629146c31bc8d8364e
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:0441267bc90fba42e25c608386845b81a0a0fcd2789c0efe84e2eff50aab8614
+    container: swiftlang/swift:nightly-main-jammy@sha256:8ecfcd63f1c127b58fef579ad4e5e48308feea1fadb8a1629146c31bc8d8364e
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-11-29-a