### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2024-12-20-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-12-17-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-12-17-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 5394f1d3c9c0067a74b8cc0597962d7ef177869a7f5fe6cbf91e8ecf58cfab24
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-12-20-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-12-20-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 12e108e1e75c93e7e91b4f8f84decd91eea9c5a9c93656108195cd0f57d088ef
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 27.0.0
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:3554e82942278de1e39fd1cb382f7651431c4f373a5b982e9709e14a5eede44c
+    container: swiftlang/swift:nightly-main-jammy@sha256:c0e579c7bf936834c789966f77e70a61c48e4f681f6336b67d7279a1572a83fe
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:3554e82942278de1e39fd1cb382f7651431c4f373a5b982e9709e14a5eede44c
+    container: swiftlang/swift:nightly-main-jammy@sha256:c0e579c7bf936834c789966f77e70a61c48e4f681f6336b67d7279a1572a83fe
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:3554e82942278de1e39fd1cb382f7651431c4f373a5b982e9709e14a5eede44c
+    container: swiftlang/swift:nightly-main-jammy@sha256:c0e579c7bf936834c789966f77e70a61c48e4f681f6336b67d7279a1572a83fe
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-12-20-a