### PR TITLE
ci: bump Swift SDK to swift-wasm-6.1-SNAPSHOT-2024-12-21-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.1"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2024-12-17-a/swift-wasm-6.1-SNAPSHOT-2024-12-17-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 97c7c93b2e1119a39c12c430ee3f05957c3ccec89bf66c56579b0005e13feac9
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2024-12-21-a/swift-wasm-6.1-SNAPSHOT-2024-12-21-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 4ffaec94290a63295bf41c7ff59e55a04796244ef2222a01688ddfaffa77f087
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 27.0.0
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:e2218ecb8a44e14c32f0d8d0410c21cc051e5ea3087103db000d71b2c4a010d0
+    container: swiftlang/swift:nightly-main-jammy@sha256:d013c36a22c265836d24c633a69ed70f00e364b813360dea4893a7b20e949ea1
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:e2218ecb8a44e14c32f0d8d0410c21cc051e5ea3087103db000d71b2c4a010d0
+    container: swiftlang/swift:nightly-main-jammy@sha256:d013c36a22c265836d24c633a69ed70f00e364b813360dea4893a7b20e949ea1
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:e2218ecb8a44e14c32f0d8d0410c21cc051e5ea3087103db000d71b2c4a010d0
+    container: swiftlang/swift:nightly-main-jammy@sha256:d013c36a22c265836d24c633a69ed70f00e364b813360dea4893a7b20e949ea1
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.1-SNAPSHOT-2024-12-21-a