### PR TITLE
ci: bump Swift SDK to swift-wasm-6.1-SNAPSHOT-2025-01-04-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.1"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2024-12-22-a/swift-wasm-6.1-SNAPSHOT-2024-12-22-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: ae42c38368ccaf114277277602c920295aab4d043e9cb7f6fbfee191c5af1903
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-01-04-a/swift-wasm-6.1-SNAPSHOT-2025-01-04-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: f566ffe282b31df90bf6f20bc745e29ae0ac9b42287efd0ba8bf141079285269
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 28.0.0
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:eb0456ae7703a55d5e1e2760aa8b80625d9c970bda3bb34a59804e21ed15bb6d
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:38309066741da58b4ae00238a1a72567331468f3a8a415bd82e7dc3e6dc81021
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:eb0456ae7703a55d5e1e2760aa8b80625d9c970bda3bb34a59804e21ed15bb6d
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:38309066741da58b4ae00238a1a72567331468f3a8a415bd82e7dc3e6dc81021
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:eb0456ae7703a55d5e1e2760aa8b80625d9c970bda3bb34a59804e21ed15bb6d
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:38309066741da58b4ae00238a1a72567331468f3a8a415bd82e7dc3e6dc81021
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.1-SNAPSHOT-2025-01-04-a