### PR TITLE
ci: bump Swift SDK to swift-wasm-6.1-SNAPSHOT-2025-01-13-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.1"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-01-11-a/swift-wasm-6.1-SNAPSHOT-2025-01-11-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: d354329e9465abc976193242b2dc36bc365e58d03c533dd7348542913d933c4e
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-01-13-a/swift-wasm-6.1-SNAPSHOT-2025-01-13-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 62303f67959b2f86a428d8a8b6fa694d99d959d3418d325e46b39970fbc524cf
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 28.0.0
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:4a4c250d58931306f1df386a6ca98fec4601bc686b35a921f18c004577ea7db0
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:c365343b41200ee3aa4ffd8193cc2518b7892604244477da6fe366974689f6a6
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:4a4c250d58931306f1df386a6ca98fec4601bc686b35a921f18c004577ea7db0
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:c365343b41200ee3aa4ffd8193cc2518b7892604244477da6fe366974689f6a6
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:4a4c250d58931306f1df386a6ca98fec4601bc686b35a921f18c004577ea7db0
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:c365343b41200ee3aa4ffd8193cc2518b7892604244477da6fe366974689f6a6
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.1-SNAPSHOT-2025-01-13-a