### PR TITLE
ci: bump wasmtime to 28.0.1

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -8,7 +8,7 @@ env:
   SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-01-13-a/swift-wasm-6.1-SNAPSHOT-2025-01-13-a-wasm32-unknown-wasi.artifactbundle.zip
   SWIFT_SDK_CHECKSUM: 62303f67959b2f86a428d8a8b6fa694d99d959d3418d325e46b39970fbc524cf
   TARGET_TRIPLE: wasm32-unknown-wasi
-  WASMTIME_VESRION: 28.0.0
+  WASMTIME_VESRION: 28.0.1
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v28.0.1