### PR TITLE
ci: bump Swift SDK to swift-wasm-6.1-SNAPSHOT-2025-01-17-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.1"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-01-15-a/swift-wasm-6.1-SNAPSHOT-2025-01-15-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 0c3c6b55866d9341b068afbe2abbbaae06f95b51cb5684e4c347c3779c3c80e9
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-01-17-a/swift-wasm-6.1-SNAPSHOT-2025-01-17-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 706b61d890e8d7b68393d032903866d4c25fa7df79459f52d63f12e12611cba3
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 28.0.1
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:433d01d0d9de6ea80ff7f977b888d24a10fa229320d81e4d7fee9c7e607f33ac
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:063167a0a0677e2e3632c87b7fe81899352234719af48e88c8670782a8924cc8
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:433d01d0d9de6ea80ff7f977b888d24a10fa229320d81e4d7fee9c7e607f33ac
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:063167a0a0677e2e3632c87b7fe81899352234719af48e88c8670782a8924cc8
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:433d01d0d9de6ea80ff7f977b888d24a10fa229320d81e4d7fee9c7e607f33ac
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:063167a0a0677e2e3632c87b7fe81899352234719af48e88c8670782a8924cc8
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.1-SNAPSHOT-2025-01-17-a