### PR TITLE
ci: bump wasmtime to 29.0.1

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -8,7 +8,7 @@ env:
   SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-01-17-a/swift-wasm-6.1-SNAPSHOT-2025-01-17-a-wasm32-unknown-wasi.artifactbundle.zip
   SWIFT_SDK_CHECKSUM: 706b61d890e8d7b68393d032903866d4c25fa7df79459f52d63f12e12611cba3
   TARGET_TRIPLE: wasm32-unknown-wasi
-  WASMTIME_VESRION: 29.0.0
+  WASMTIME_VESRION: 29.0.1
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v29.0.1