### PR TITLE
ci: bump Swift SDK to swift-wasm-6.1-SNAPSHOT-2025-02-19-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.1"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-02-18-a/swift-wasm-6.1-SNAPSHOT-2025-02-18-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: ad01781476e13b411c71042391f9a3d6382f14135a7fc465b886b76dc2b6f41c
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-02-19-a/swift-wasm-6.1-SNAPSHOT-2025-02-19-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: cfa800f70fbc11abcc2c4ca579f85290b2a96a247896964c4f23b4eba63888b6
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 30.0.0
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:ff15feb3bf50ff4601fb72c2a320dc48baf4556d8d92c2cd57d2ffca0ac7a09c
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:9922d7931728e899da509e0133b8f5920a6297fabf949cb4b9f0449d2ca35e84
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:ff15feb3bf50ff4601fb72c2a320dc48baf4556d8d92c2cd57d2ffca0ac7a09c
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:9922d7931728e899da509e0133b8f5920a6297fabf949cb4b9f0449d2ca35e84
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:ff15feb3bf50ff4601fb72c2a320dc48baf4556d8d92c2cd57d2ffca0ac7a09c
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:9922d7931728e899da509e0133b8f5920a6297fabf949cb4b9f0449d2ca35e84
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.1-SNAPSHOT-2025-02-19-a