### PR TITLE
ci: bump Swift SDK to swift-wasm-6.1-SNAPSHOT-2025-03-04-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.1"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-03-03-a/swift-wasm-6.1-SNAPSHOT-2025-03-03-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 2076ab37a1dacfb848996e039378b325ab001c291ca2116d92db2b2df82de362
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-SNAPSHOT-2025-03-04-a/swift-wasm-6.1-SNAPSHOT-2025-03-04-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 6aa33ca861e03eb1a91fd559fc8e6df117d1ff16f4a8ef3fd8fd130520a43403
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 30.0.2
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:01dd4edbe7dd2a92008769cb346bfe6ede3833754ba13f15a5d093edb6ea91e1
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:a6894c18165efd1d5c6eede0d209077c3c43029a1e5349fbc2259721c5b4fa55
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:01dd4edbe7dd2a92008769cb346bfe6ede3833754ba13f15a5d093edb6ea91e1
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:a6894c18165efd1d5c6eede0d209077c3c43029a1e5349fbc2259721c5b4fa55
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.1-jammy@sha256:01dd4edbe7dd2a92008769cb346bfe6ede3833754ba13f15a5d093edb6ea91e1
+    container: swiftlang/swift:nightly-6.1-jammy@sha256:a6894c18165efd1d5c6eede0d209077c3c43029a1e5349fbc2259721c5b4fa55
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.1-SNAPSHOT-2025-03-04-a