### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-04-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-02-18-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-02-18-a-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: e9d93d77db491c55fa86909a0530d95f069c9eef5bf999617c27b9d065414314
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-04-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-04-a-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 99e312607dfa5adaef2783e7079adc354c51e96a0b0b5a97d2be0953425b5990
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 30.0.2
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:ff675b06b5e6b96a0ee3b433cbd0e8a54591d11f928ca15c4a5bb39fda978dc1
+    container: swiftlang/swift:nightly-main-jammy@sha256:75ed181a139768455f5c480b0a76df89bed44ce92d26ee2fd5c7ca7b9a67d90e
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:ff675b06b5e6b96a0ee3b433cbd0e8a54591d11f928ca15c4a5bb39fda978dc1
+    container: swiftlang/swift:nightly-main-jammy@sha256:75ed181a139768455f5c480b0a76df89bed44ce92d26ee2fd5c7ca7b9a67d90e
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -49,7 +49,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy@sha256:ff675b06b5e6b96a0ee3b433cbd0e8a54591d11f928ca15c4a5bb39fda978dc1
+    container: swiftlang/swift:nightly-main-jammy@sha256:75ed181a139768455f5c480b0a76df89bed44ce92d26ee2fd5c7ca7b9a67d90e
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-03-04-a