### PR TITLE
ci: bump Swift SDK to swift-wasm-6.0.3-RELEASE

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.0"]
 env:
-  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0.2-RELEASE/swift-wasm-6.0.2-RELEASE-wasm32-unknown-wasi.artifactbundle.zip
-  SWIFT_SDK_CHECKSUM: 6ffedb055cb9956395d9f435d03d53ebe9f6a8d45106b979d1b7f53358e1dcb4
+  SWIFT_SDK_URL: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.0.3-RELEASE/swift-wasm-6.0.3-RELEASE-wasm32-unknown-wasi.artifactbundle.zip
+  SWIFT_SDK_CHECKSUM: 31d3585b06dd92de390bacc18527801480163188cd7473f492956b5e213a8618
   TARGET_TRIPLE: wasm32-unknown-wasi
   WASMTIME_VESRION: 26.0.1
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: swift:6.0.2-noble
+    container: swift:6.0.3-noble
     env:
       STACK_SIZE: 524288
     steps:
@@ -34,7 +34,7 @@ jobs:
   test-binary:
     needs: build
     runs-on: ubuntu-latest
-    container: swift:6.0.2-noble
+    container: swift:6.0.3-noble
     steps:
       - uses: actions/checkout@v4
       - name: Install tools
@@ -50,7 +50,7 @@ jobs:
       - run: wasmtime --dir . swift-format.wasm lint -r .
   test:
     runs-on: ubuntu-latest
-    container: swift:6.0.2-noble
+    container: swift:6.0.3-noble
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-6.0.3-RELEASE