### PR TITLE
ci: bump Swift SDK to swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-30-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -13,18 +13,12 @@ jobs:
         target:
           - triple: wasm32-unknown-wasi
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 44c06fb80f9ec9f489982a118c5c8977fa73909479ae3725cf09c09a9506b326
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-30-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-30-a_wasm.artifactbundle.tar.gz
+              checksum: c55777bd47790c9ee728380b4d4e145153f805432775511777ac89d07b559226
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
-          - triple: wasm32-unknown-wasip1-threads
-            sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: 1bc46ee00a9e0c23feaba085533b83903a5fe3991596689928efd9df1de757ea
-            artifact-name: swift-format-threads.wasm
-            other-wasmopt-flags: --enable-threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:2d76e55473e8f2295137027de5aa0e0f8032bd60484f033d3e958cf588b00d4c
+    container: swiftlang/swift:nightly-main-noble@sha256:67efd3f092b810d27ad21d90b9ab32fbbcead75df80dfcfa73bb773c80f104ca
     env:
       STACK_SIZE: 524288
     steps:
@@ -50,10 +44,8 @@ jobs:
         target:
           - artifact-name: swift-format.wasm
             other-wasmtime-flags:
-          - artifact-name: swift-format-threads.wasm
-            other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:2d76e55473e8f2295137027de5aa0e0f8032bd60484f033d3e958cf588b00d4c
+    container: swiftlang/swift:nightly-main-noble@sha256:67efd3f092b810d27ad21d90b9ab32fbbcead75df80dfcfa73bb773c80f104ca
     steps:
       - uses: actions/checkout@v4
       - name: Install tools
@@ -74,16 +66,11 @@ jobs:
         target:
           - triple: wasm32-unknown-wasi
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 44c06fb80f9ec9f489982a118c5c8977fa73909479ae3725cf09c09a9506b326
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-30-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-05-30-a_wasm.artifactbundle.tar.gz
+              checksum: c55777bd47790c9ee728380b4d4e145153f805432775511777ac89d07b559226
             other-wasmtime-flags:
-          - triple: wasm32-unknown-wasip1-threads
-            sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: 1bc46ee00a9e0c23feaba085533b83903a5fe3991596689928efd9df1de757ea
-            other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:2d76e55473e8f2295137027de5aa0e0f8032bd60484f033d3e958cf588b00d4c
+    container: swiftlang/swift:nightly-main-noble@sha256:67efd3f092b810d27ad21d90b9ab32fbbcead75df80dfcfa73bb773c80f104ca
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
Swift SDK for Wasm is now published on swift.org, but it doesn't seem to have an SDK for wasm32-Wasip1-threads.