### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -13,18 +13,18 @@ jobs:
         target:
           - triple: wasm32-unknown-wasi
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-01-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-01-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 4d4b53651a8b06ed2b5ec0cd6a25e2a078ab759c15df4fecaabf3c3c8816adae
+              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a-wasm32-unknown-wasi.artifactbundle.zip
+              checksum: 937c6c583d874abf9ce6f735387bd2238c2c4ecfe5176de8b56ed4865efbd588
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
           - triple: wasm32-unknown-wasip1-threads
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-01-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-01-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: 77cf7aef9e611eb9a956ad33dbfd0a85cec8a1b08c47ac16842dd34ec889b091
+              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
+              checksum: 0d052d2122dc76ccb2cae10eecae9359e2855143b5488d152828884ff3eb4089
             artifact-name: swift-format-threads.wasm
             other-wasmopt-flags: --enable-threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:338419700463c9aba1361d68f711b322acefa7149d83285cf2ebd85a30e5e361
+    container: swiftlang/swift:nightly-main-noble@sha256:fef4d887990784bbf396c142796a18db91a0cdab476b0a1d4ce7209acbeed2fa
     env:
       STACK_SIZE: 524288
     steps:
@@ -53,7 +53,7 @@ jobs:
           - artifact-name: swift-format-threads.wasm
             other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:338419700463c9aba1361d68f711b322acefa7149d83285cf2ebd85a30e5e361
+    container: swiftlang/swift:nightly-main-noble@sha256:fef4d887990784bbf396c142796a18db91a0cdab476b0a1d4ce7209acbeed2fa
     steps:
       - uses: actions/checkout@v4
       - name: Install tools
@@ -74,16 +74,16 @@ jobs:
         target:
           - triple: wasm32-unknown-wasi
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-01-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-01-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 4d4b53651a8b06ed2b5ec0cd6a25e2a078ab759c15df4fecaabf3c3c8816adae
+              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a-wasm32-unknown-wasi.artifactbundle.zip
+              checksum: 937c6c583d874abf9ce6f735387bd2238c2c4ecfe5176de8b56ed4865efbd588
             other-wasmtime-flags:
           - triple: wasm32-unknown-wasip1-threads
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-01-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-01-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: 77cf7aef9e611eb9a956ad33dbfd0a85cec8a1b08c47ac16842dd34ec889b091
+              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
+              checksum: 0d052d2122dc76ccb2cae10eecae9359e2855143b5488d152828884ff3eb4089
             other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:338419700463c9aba1361d68f711b322acefa7149d83285cf2ebd85a30e5e361
+    container: swiftlang/swift:nightly-main-noble@sha256:fef4d887990784bbf396c142796a18db91a0cdab476b0a1d4ce7209acbeed2fa
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-12-a