### PR TITLE
fix: fix ArgumentParser build failure for WASI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -200,7 +200,7 @@ var dependencies: [Package.Dependency] {
     ]
   } else {
     return [
-      .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
+      .package(url: "https://github.com/kkebo/swift-argument-parser.git", branch: "wasm32-wasi"),
       .package(url: "https://github.com/kkebo/swift-markdown.git", branch: "swift-markdown-wasm32-wasi-0.6"),
       .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),
     ]


### PR DESCRIPTION
apple/swift-argument-parser has been broken for wasm32-unknown-wasi since 1.6.0, so I'm replacing it with my patched branch temporarily.