### PR TITLE
revert: partially revert "replace apple/swift-argument-parser with kkebo/swift-argument-parser"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -200,7 +200,10 @@ var dependencies: [Package.Dependency] {
     ]
   } else {
     return [
-      .package(url: "https://github.com/kkebo/swift-argument-parser.git", branch: "wasm32-wasi"),
+      .package(
+        url: "https://github.com/apple/swift-argument-parser.git",
+        revision: "d075877f3a7a06e75d46b3c3275dcba0ac9c9f9b"
+      ),  // TODO: Revert this to `from: "1.2.2"` when the next version is released.
       .package(url: "https://github.com/kkebo/swift-markdown.git", branch: "swift-markdown-wasm32-wasi-0.6"),
       .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: "main"),
     ]


### PR DESCRIPTION
swift-argument-parser has been fixed, so I'm partially reverting #412.