### PR TITLE
ci: bump Swift SDK to swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -13,18 +13,18 @@ jobs:
         target:
           - triple: wasm32-unknown-wasi
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 37516de837411ea46e4f9e75d52bd742f6941febac49981aac0c4f20f02b8b54
+              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a-wasm32-unknown-wasi.artifactbundle.zip
+              checksum: 249e8fc0dd6bc5e31583d6c63c778830ff0e3b9f98cff7ee6b31b2decf5f87cb
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
           - triple: wasm32-unknown-wasip1-threads
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: aeaae676e2e259a6bd84cc80ad04f881137c92e264278150fe4a2f5a151f3ae9
+              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
+              checksum: 9d273f7b5e26bffa284a386833bb1675a04c7e177f67c58725fea41c1bc63f5a
             artifact-name: swift-format-threads.wasm
             other-wasmopt-flags: --enable-threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:9312a6c5955840c04b287a71cb6ee77dad8aeed8f5feea817e088bd0ab2364b7
+    container: swiftlang/swift:nightly-main-noble@sha256:431010bdc206a7bc0c2556f9b09200a0d876f504fe4e05b357147767581cc8d8
     env:
       STACK_SIZE: 524288
     steps:
@@ -53,7 +53,7 @@ jobs:
           - artifact-name: swift-format-threads.wasm
             other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:9312a6c5955840c04b287a71cb6ee77dad8aeed8f5feea817e088bd0ab2364b7
+    container: swiftlang/swift:nightly-main-noble@sha256:431010bdc206a7bc0c2556f9b09200a0d876f504fe4e05b357147767581cc8d8
     steps:
       - uses: actions/checkout@v4
       - name: Install tools
@@ -74,16 +74,16 @@ jobs:
         target:
           - triple: wasm32-unknown-wasi
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 37516de837411ea46e4f9e75d52bd742f6941febac49981aac0c4f20f02b8b54
+              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a-wasm32-unknown-wasi.artifactbundle.zip
+              checksum: 249e8fc0dd6bc5e31583d6c63c778830ff0e3b9f98cff7ee6b31b2decf5f87cb
             other-wasmtime-flags:
           - triple: wasm32-unknown-wasip1-threads
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-06-22-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: aeaae676e2e259a6bd84cc80ad04f881137c92e264278150fe4a2f5a151f3ae9
+              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
+              checksum: 9d273f7b5e26bffa284a386833bb1675a04c7e177f67c58725fea41c1bc63f5a
             other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:9312a6c5955840c04b287a71cb6ee77dad8aeed8f5feea817e088bd0ab2364b7
+    container: swiftlang/swift:nightly-main-noble@sha256:431010bdc206a7bc0c2556f9b09200a0d876f504fe4e05b357147767581cc8d8
     env:
       STACK_SIZE: 4194304
     steps:


### PR DESCRIPTION
https://github.com/swiftwasm/swift/releases/tag/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-07-18-a