### PR TITLE
ci: use swiftly instead of swiftlang/swift images

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi"]
 env:
+  SWIFT_VERSION: main-snapshot-2025-07-18
   WASMTIME_VESRION: 35.0.0
 jobs:
   build:
@@ -24,13 +25,17 @@ jobs:
             artifact-name: swift-format-threads.wasm
             other-wasmopt-flags: --enable-threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:431010bdc206a7bc0c2556f9b09200a0d876f504fe4e05b357147767581cc8d8
     env:
       STACK_SIZE: 524288
     steps:
       - uses: actions/checkout@v4
       - name: Install tools
-        run: apt-get update && apt-get install --no-install-recommends -y wabt binaryen unzip
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y wabt binaryen
+      - run: ./Scripts/ci-install-swiftly.sh
+      - name: swiftly install
+        run: |
+          curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
+          swiftly install -y --use ${{ env.SWIFT_VERSION }}
       - run: swift --version
       - run: swift sdk install ${{ matrix.target.sdk.url }} --checksum ${{ matrix.target.sdk.checksum }}
       - name: Build
@@ -53,11 +58,13 @@ jobs:
           - artifact-name: swift-format-threads.wasm
             other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:431010bdc206a7bc0c2556f9b09200a0d876f504fe4e05b357147767581cc8d8
     steps:
       - uses: actions/checkout@v4
-      - name: Install tools
-        run: apt-get update && apt-get install --no-install-recommends -y xz-utils
+      - run: ./Scripts/ci-install-swiftly.sh
+      - name: swiftly install
+        run: |
+          curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
+          swiftly install -y --use ${{ env.SWIFT_VERSION }}
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
           version: ${{ env.WASMTIME_VERSION }}
@@ -83,13 +90,15 @@ jobs:
               checksum: 9d273f7b5e26bffa284a386833bb1675a04c7e177f67c58725fea41c1bc63f5a
             other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:431010bdc206a7bc0c2556f9b09200a0d876f504fe4e05b357147767581cc8d8
     env:
       STACK_SIZE: 4194304
     steps:
       - uses: actions/checkout@v4
-      - name: Install tools
-        run: apt-get update && apt-get install --no-install-recommends -y xz-utils unzip
+      - run: ./Scripts/ci-install-swiftly.sh
+      - name: swiftly install
+        run: |
+          curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
+          swiftly install -y --use ${{ env.SWIFT_VERSION }}
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
           version: ${{ env.WASMTIME_VERSION }}

--- a/Scripts/ci-install-swiftly.sh
+++ b/Scripts/ci-install-swiftly.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+##===----------------------------------------------------------------------===##
+
+sudo apt-get update && sudo apt-get install --no-install-recommends -y libcurl4-openssl-dev
+
+curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
+tar zxf "swiftly-$(uname -m).tar.gz"
+./swiftly init -y --skip-install -n
+# shellcheck disable=SC1091
+. "$HOME/.local/share/swiftly/env.sh"
+hash -r
+
+echo "PATH=$PATH" >> "$GITHUB_ENV" && echo "SWIFTLY_HOME_DIR=$SWIFTLY_HOME_DIR" >> "$GITHUB_ENV" && echo "SWIFTLY_BIN_DIR=$SWIFTLY_BIN_DIR" >> "$GITHUB_ENV" && echo "SWIFTLY_TOOLCHAINS_DIR=$SWIFTLY_TOOLCHAINS_DIR" >> "$GITHUB_ENV"


### PR DESCRIPTION
Pros:

- We can use the latest nightly toolchain as soon as possible.
- We no longer need to worry about the gzip issue.

Cons:

- CI execution time is a little bit longer.