### PR TITLE
ci: use swiftly instead of swiftlang/swift images

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
+  SWIFT_VERSION: 6.2-snapshot-2025-04-03
   WASMTIME_VESRION: 35.0.0
 jobs:
   build:
@@ -24,13 +25,17 @@ jobs:
             artifact-name: swift-format-threads.wasm
             other-wasmopt-flags: --enable-threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:2d76e55473e8f2295137027de5aa0e0f8032bd60484f033d3e958cf588b00d4c
     env:
       STACK_SIZE: 524288
     steps:
       - uses: actions/checkout@v4
       - name: Install tools
-        run: apt-get update && apt-get install --no-install-recommends -y wabt binaryen unzip
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y wabt binaryen
+      - run: ./Scripts/ci-install-swiftly.sh
+      - name: swiftly install
+        run: |
+          curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
+          swiftly install -y --use ${{ env.SWIFT_VERSION }}
       - run: swift --version
       - run: swift sdk install ${{ matrix.target.sdk.url }} --checksum ${{ matrix.target.sdk.checksum }}
       - name: Build
@@ -53,11 +58,13 @@ jobs:
           - artifact-name: swift-format-threads.wasm
             other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:2d76e55473e8f2295137027de5aa0e0f8032bd60484f033d3e958cf588b00d4c
     steps:
       - uses: actions/checkout@v4
-      - name: Install tools
-        run: apt-get update && apt-get install --no-install-recommends -y xz-utils
+      - run: ./Scripts/ci-install-swiftly.sh
+      - name: swiftly install
+        run: |
+          curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
+          swiftly install -y --use ${{ env.SWIFT_VERSION }}
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
           version: ${{ env.WASMTIME_VERSION }}
@@ -83,13 +90,15 @@ jobs:
               checksum: 1bc46ee00a9e0c23feaba085533b83903a5fe3991596689928efd9df1de757ea
             other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
-    container: swiftlang/swift:nightly-main-noble@sha256:2d76e55473e8f2295137027de5aa0e0f8032bd60484f033d3e958cf588b00d4c
     env:
       STACK_SIZE: 4194304
     steps:
       - uses: actions/checkout@v4
-      - name: Install tools
-        run: apt-get update && apt-get install --no-install-recommends -y xz-utils unzip
+      - run: ./Scripts/ci-install-swiftly.sh
+      - name: swiftly install
+        run: |
+          curl --silent --retry 3 --location --fail --compressed https://swift.org/keys/all-keys.asc | gpg --import -
+          swiftly install -y --use ${{ env.SWIFT_VERSION }}
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         with:
           version: ${{ env.WASMTIME_VERSION }}

--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,25 +5,19 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
-  SWIFT_VERSION: 6.2-snapshot-2025-04-03
+  SWIFT_VERSION: 6.2-snapshot-2025-07-23
   WASMTIME_VESRION: 35.0.0
 jobs:
   build:
     strategy:
       matrix:
         target:
-          - triple: wasm32-unknown-wasi
+          - triple: wasm32-unknown-wasip1
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 44c06fb80f9ec9f489982a118c5c8977fa73909479ae3725cf09c09a9506b326
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm.artifactbundle.tar.gz
+              checksum: 0294f106efcf4ca8944da5284b7a12825e9c4ca1316daa3f45d05ea0f65bedff
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
-          - triple: wasm32-unknown-wasip1-threads
-            sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: 1bc46ee00a9e0c23feaba085533b83903a5fe3991596689928efd9df1de757ea
-            artifact-name: swift-format-threads.wasm
-            other-wasmopt-flags: --enable-threads
     runs-on: ubuntu-24.04-arm
     env:
       STACK_SIZE: 524288
@@ -55,8 +49,6 @@ jobs:
         target:
           - artifact-name: swift-format.wasm
             other-wasmtime-flags:
-          - artifact-name: swift-format-threads.wasm
-            other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -79,16 +71,11 @@ jobs:
     strategy:
       matrix:
         target:
-          - triple: wasm32-unknown-wasi
+          - triple: wasm32-unknown-wasip1
             sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a-wasm32-unknown-wasi.artifactbundle.zip
-              checksum: 44c06fb80f9ec9f489982a118c5c8977fa73909479ae3725cf09c09a9506b326
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm.artifactbundle.tar.gz
+              checksum: 0294f106efcf4ca8944da5284b7a12825e9c4ca1316daa3f45d05ea0f65bedff
             other-wasmtime-flags:
-          - triple: wasm32-unknown-wasip1-threads
-            sdk:
-              url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2025-04-03-a-wasm32-unknown-wasip1-threads.artifactbundle.zip
-              checksum: 1bc46ee00a9e0c23feaba085533b83903a5fe3991596689928efd9df1de757ea
-            other-wasmtime-flags: --wasi threads
     runs-on: ubuntu-24.04-arm
     env:
       STACK_SIZE: 4194304

--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         target:
-          - triple: wasm32-unknown-wasip1
-            sdk:
+          - sdk:
               url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm.artifactbundle.tar.gz
               checksum: 0294f106efcf4ca8944da5284b7a12825e9c4ca1316daa3f45d05ea0f65bedff
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -34,7 +34,7 @@ jobs:
       - run: swift sdk install ${{ matrix.target.sdk.url }} --checksum ${{ matrix.target.sdk.checksum }}
       - name: Build
         run: |
-          swift build --product swift-format --swift-sdk ${{ matrix.target.triple }} -c release -Xlinker -z -Xlinker stack-size=$STACK_SIZE
+          swift build --product swift-format --swift-sdk ${{ matrix.target.sdk.id }} -c release -Xlinker -z -Xlinker stack-size=$STACK_SIZE
           wasm-strip .build/release/swift-format.wasm
           wasm-opt -Oz --enable-bulk-memory --enable-sign-ext ${{ matrix.target.other-wasmopt-flags }} .build/release/swift-format.wasm -o ${{ matrix.target.artifact-name }}
       - name: Upload ${{ matrix.target.artifact-name }}
@@ -71,10 +71,10 @@ jobs:
     strategy:
       matrix:
         target:
-          - triple: wasm32-unknown-wasip1
-            sdk:
+          - sdk:
               url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm.artifactbundle.tar.gz
               checksum: 0294f106efcf4ca8944da5284b7a12825e9c4ca1316daa3f45d05ea0f65bedff
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-23-a_wasm
             other-wasmtime-flags:
     runs-on: ubuntu-24.04-arm
     env:
@@ -92,5 +92,5 @@ jobs:
       - run: swift --version
       - run: wasmtime -V
       - run: swift sdk install ${{ matrix.target.sdk.url }} --checksum ${{ matrix.target.sdk.checksum }}
-      - run: swift build -c release --build-tests --swift-sdk ${{ matrix.target.triple }} -Xlinker -z -Xlinker stack-size=$STACK_SIZE
+      - run: swift build -c release --build-tests --swift-sdk ${{ matrix.target.sdk.id }} -Xlinker -z -Xlinker stack-size=$STACK_SIZE
       - run: wasmtime --dir / --wasm max-wasm-stack=$STACK_SIZE ${{ matrix.target.other-wasmtime-flags }} .build/release/swift-formatPackageTests.xctest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The WebAssembly (WASI) version of `swift-format`. This project's goal is to be m
 
 ## Download
 
-You can download `swift-format.wasm` (wasm32-unknown-wasi) and `swift-format-threads.wasm` (wasm32-unknown-wasip1-threads) from the following pages.
+You can download `swift-format.wasm` from the following pages.
 
 - stable
   - [Releases](https://github.com/kkebo/swift-format/releases)

--- a/Scripts/ci-install-swiftly.sh
+++ b/Scripts/ci-install-swiftly.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift.org open source project
+##
+## Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+## Licensed under Apache License v2.0 with Runtime Library Exception
+##
+## See https://swift.org/LICENSE.txt for license information
+## See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+##
+##===----------------------------------------------------------------------===##
+
+sudo apt-get update && sudo apt-get install --no-install-recommends -y libcurl4-openssl-dev
+
+curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz"
+tar zxf "swiftly-$(uname -m).tar.gz"
+./swiftly init -y --skip-install -n
+# shellcheck disable=SC1091
+. "$HOME/.local/share/swiftly/env.sh"
+hash -r
+
+echo "PATH=$PATH" >> "$GITHUB_ENV" && echo "SWIFTLY_HOME_DIR=$SWIFTLY_HOME_DIR" >> "$GITHUB_ENV" && echo "SWIFTLY_BIN_DIR=$SWIFTLY_BIN_DIR" >> "$GITHUB_ENV" && echo "SWIFTLY_TOOLCHAINS_DIR=$SWIFTLY_TOOLCHAINS_DIR" >> "$GITHUB_ENV"


### PR DESCRIPTION
Pros:

- We can use the latest nightly toolchain as soon as possible.
- We no longer need to worry about the gzip issue.

Cons:

- CI execution time is a little bit longer.