### PR TITLE
ci: bump Swift SDK to swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-29-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
-  SWIFT_VERSION: 6.2-snapshot-2025-07-26
+  SWIFT_VERSION: 6.2-snapshot-2025-07-29
   WASMTIME_VESRION: 35.0.0
 jobs:
   build:
@@ -13,9 +13,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-26-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-26-a_wasm.artifactbundle.tar.gz
-              checksum: 2ff6242bb1396ed19f935ea5a3e169543baf401f9a6a6386cf59dab6fdf0d814
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-26-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-29-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-29-a_wasm.artifactbundle.tar.gz
+              checksum: ae4a165a8ee29a1149cb79fa4b0b6cda7a16434d3e39c9d6b049c39050e5cbdf
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-29-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -72,9 +72,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-26-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-26-a_wasm.artifactbundle.tar.gz
-              checksum: 2ff6242bb1396ed19f935ea5a3e169543baf401f9a6a6386cf59dab6fdf0d814
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-26-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-29-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-29-a_wasm.artifactbundle.tar.gz
+              checksum: ae4a165a8ee29a1149cb79fa4b0b6cda7a16434d3e39c9d6b049c39050e5cbdf
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-07-29-a_wasm
             other-wasmtime-flags:
     runs-on: ubuntu-24.04-arm
     env:


### PR DESCRIPTION
https://github.com/swiftlang/swift-org-website/commit/291e7a5be34c340d5c0bd91ad5e1de0c0471ab24