### PR TITLE
ci: bump Swift SDK to swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
-  SWIFT_VERSION: 6.2-snapshot-2025-08-01
+  SWIFT_VERSION: 6.2-snapshot-2025-08-06
   WASMTIME_VESRION: 35.0.0
 jobs:
   build:
@@ -13,9 +13,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-01-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-01-a_wasm.artifactbundle.tar.gz
-              checksum: 40f3c780d4a8f3d369c203615330e1b00441b6f8b7023535bebc16bf4dd5f84a
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-01-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm.artifactbundle.tar.gz
+              checksum: 04947ef393099d48764e56ab47cf62587fa69e35e671d9f66ee41f25bbe9e7c0
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -68,9 +68,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-01-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-01-a_wasm.artifactbundle.tar.gz
-              checksum: 40f3c780d4a8f3d369c203615330e1b00441b6f8b7023535bebc16bf4dd5f84a
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-01-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm.artifactbundle.tar.gz
+              checksum: 04947ef393099d48764e56ab47cf62587fa69e35e671d9f66ee41f25bbe9e7c0
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm
             other-wasmtime-flags:
     runs-on: ubuntu-24.04-arm
     env:


### PR DESCRIPTION
https://github.com/swiftlang/swift-org-website/commit/5dabd85c27190c7fb446c121f2189eb4a4f29186