### PR TITLE
ci: bump Swift SDK to swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-07-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
-  SWIFT_VERSION: 6.2-snapshot-2025-08-06
+  SWIFT_VERSION: 6.2-snapshot-2025-08-07
   WASMTIME_VESRION: 35.0.0
 jobs:
   build:
@@ -13,9 +13,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm.artifactbundle.tar.gz
-              checksum: 04947ef393099d48764e56ab47cf62587fa69e35e671d9f66ee41f25bbe9e7c0
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-07-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-07-a_wasm.artifactbundle.tar.gz
+              checksum: bb68481b5fb3dbfdd75c8947c0ea052d3e0528f3241fcf8db98f19c80fe62d56
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-07-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -68,9 +68,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm.artifactbundle.tar.gz
-              checksum: 04947ef393099d48764e56ab47cf62587fa69e35e671d9f66ee41f25bbe9e7c0
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-06-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-07-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-07-a_wasm.artifactbundle.tar.gz
+              checksum: bb68481b5fb3dbfdd75c8947c0ea052d3e0528f3241fcf8db98f19c80fe62d56
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-07-a_wasm
             other-wasmtime-flags:
     runs-on: ubuntu-24.04-arm
     env:


### PR DESCRIPTION
https://github.com/swiftlang/swift-org-website/commit/4725477660742c7c36fed3ad7f0f18febaeb6882