### PR TITLE
ci: bump Swift SDK to swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-13-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
-  SWIFT_VERSION: 6.2-snapshot-2025-08-10
+  SWIFT_VERSION: 6.2-snapshot-2025-08-13
   WASMTIME_VESRION: 35.0.0
 jobs:
   build:
@@ -13,9 +13,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-10-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-10-a_wasm.artifactbundle.tar.gz
-              checksum: 8e4ab72cb0ab892861705f1f133bfc4f62bb33376fdcf6fec9c8128a44b95947
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-10-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-13-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-13-a_wasm.artifactbundle.tar.gz
+              checksum: dd3e870a74eb901e25f4df2a684ca2ca5e0c74835332fc8ae125a775ee911567
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-13-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -68,9 +68,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-10-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-10-a_wasm.artifactbundle.tar.gz
-              checksum: 8e4ab72cb0ab892861705f1f133bfc4f62bb33376fdcf6fec9c8128a44b95947
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-10-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-13-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-13-a_wasm.artifactbundle.tar.gz
+              checksum: dd3e870a74eb901e25f4df2a684ca2ca5e0c74835332fc8ae125a775ee911567
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-13-a_wasm
             other-wasmtime-flags:
     runs-on: ubuntu-24.04-arm
     env:


### PR DESCRIPTION
https://github.com/swiftlang/swift-org-website/commit/26be46bd6212e0e891c84ad3ec77852713d1542d