### PR TITLE
ci: bump Swift SDK to swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-19-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
-  SWIFT_VERSION: 6.2-snapshot-2025-08-14
+  SWIFT_VERSION: 6.2-snapshot-2025-08-19
   WASMTIME_VESRION: 35.0.0
 jobs:
   build:
@@ -13,9 +13,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-14-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-14-a_wasm.artifactbundle.tar.gz
-              checksum: 9ce35793a58b41423cc93db9f516214b508cbd574a21f002249e2780136a4bab
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-14-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-19-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-19-a_wasm.artifactbundle.tar.gz
+              checksum: 3c7f7bc8b72798e2b70204e8ccfdb2773975165a1d3db4f49572e6de1a5ec82f
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-19-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -68,9 +68,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-14-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-14-a_wasm.artifactbundle.tar.gz
-              checksum: 9ce35793a58b41423cc93db9f516214b508cbd574a21f002249e2780136a4bab
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-14-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-19-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-19-a_wasm.artifactbundle.tar.gz
+              checksum: 3c7f7bc8b72798e2b70204e8ccfdb2773975165a1d3db4f49572e6de1a5ec82f
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-08-19-a_wasm
             other-wasmtime-flags:
     runs-on: ubuntu-24.04-arm
     env:


### PR DESCRIPTION
https://github.com/swiftlang/swift-org-website/commit/4401243a4fa7d1b3cc2cef03511b5ccec6960e63