### PR TITLE
ci: bump wasmtime to 36.0.1

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -6,7 +6,7 @@ on:
     branches: ["wasm32-wasi-release/6.2.0"]
 env:
   SWIFT_VERSION: 6.2-snapshot-2025-08-10
-  WASMTIME_VESRION: 36.0.0
+  WASMTIME_VESRION: 36.0.1
 jobs:
   build:
     strategy:


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v36.0.1