### PR TITLE
ci: bump wasmtime to 37.0.0

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -6,7 +6,7 @@ on:
     branches: ["wasm32-wasi"]
 env:
   SWIFT_VERSION: main-snapshot-2025-09-19
-  WASMTIME_VESRION: 36.0.2
+  WASMTIME_VESRION: 37.0.0
 jobs:
   build:
     strategy:


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v37.0.0