### PR TITLE
ci: bump Swift SDK to swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-24-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
-  SWIFT_VERSION: 6.2-snapshot-2025-09-20
+  SWIFT_VERSION: 6.2-snapshot-2025-09-24
   WASMTIME_VESRION: 37.0.1
 jobs:
   build:
@@ -13,9 +13,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-20-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-20-a_wasm.artifactbundle.tar.gz
-              checksum: f9b5590c1238994d99f6232ac058ae27cb2d0517e329d396e4c99c22edadd522
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-20-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-24-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-24-a_wasm.artifactbundle.tar.gz
+              checksum: ad0457d04c1fbae9e0667da0b1c8dddcdd4be377ce788bdd57878ea1a82904ed
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-24-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -62,9 +62,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-20-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-20-a_wasm.artifactbundle.tar.gz
-              checksum: f9b5590c1238994d99f6232ac058ae27cb2d0517e329d396e4c99c22edadd522
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-20-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-24-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-24-a_wasm.artifactbundle.tar.gz
+              checksum: ad0457d04c1fbae9e0667da0b1c8dddcdd4be377ce788bdd57878ea1a82904ed
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-24-a_wasm
             other-wasmtime-flags:
     runs-on: ubuntu-24.04-arm
     env:


### PR DESCRIPTION
https://github.com/swiftlang/swift-org-website/commit/edc5c2390a0669e095b0475376ad564989985dba