### PR TITLE
ci: bump Swift SDK to swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-29-a_wasm

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.2"]
 env:
-  SWIFT_VERSION: 6.2-snapshot-2025-09-27
+  SWIFT_VERSION: 6.2-snapshot-2025-09-29
   WASMTIME_VESRION: 37.0.1
 jobs:
   build:
@@ -13,9 +13,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-27-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-27-a_wasm.artifactbundle.tar.gz
-              checksum: 2535f53de0ada00a74bd097d36d94f6b41670b34a877c236850ee28194cb36d2
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-27-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-29-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-29-a_wasm.artifactbundle.tar.gz
+              checksum: 26b076537508fe75dba8eff381427149887f304d97c5df598951308a42e6b719
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-29-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -62,9 +62,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-27-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-27-a_wasm.artifactbundle.tar.gz
-              checksum: 2535f53de0ada00a74bd097d36d94f6b41670b34a877c236850ee28194cb36d2
-              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-27-a_wasm
+              url: https://download.swift.org/swift-6.2-branch/wasm-sdk/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-29-a/swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-29-a_wasm.artifactbundle.tar.gz
+              checksum: 26b076537508fe75dba8eff381427149887f304d97c5df598951308a42e6b719
+              id: swift-6.2-DEVELOPMENT-SNAPSHOT-2025-09-29-a_wasm
             other-wasmtime-flags:
     runs-on: ubuntu-24.04-arm
     env:


### PR DESCRIPTION
https://github.com/swiftlang/swift-org-website/commit/1dd5846759602bba27ab70da32f2a97f57ea0f1b