### PR TITLE
ci: bump wasmtime to 44.0.0

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -6,7 +6,7 @@ on:
     branches: ["wasm32-wasi"]
 env:
   SWIFT_VERSION: main-snapshot-2026-03-16
-  WASMTIME_VERSION: 43.0.0
+  WASMTIME_VERSION: 44.0.0
 permissions: {}
 defaults:
   run:


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v44.0.0