### PR TITLE
ci: add 6.4 branches to pull.yml

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -42,3 +42,17 @@ rules:
       - kkebo
     reviewers:
       - kkebo
+  - base: release/6.4.x
+    upstream: swiftlang:release/6.4.x
+    mergeMethod: hardreset
+    assignees:
+      - kkebo
+    reviewers:
+      - kkebo
+  - base: wasm32-wasi-release/6.4.x
+    upstream: release/6.4.x
+    mergeMethod: merge
+    assignees:
+      - kkebo
+    reviewers:
+      - kkebo


### PR DESCRIPTION
The `release/6.4.x` branch has been cut on the upstream repo.