### PR TITLE
ci: bump Swift SDK to swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-03-a

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: ["wasm32-wasi-release/6.4.x"]
 env:
-  SWIFT_VERSION: main-snapshot-2026-03-16
+  SWIFT_VERSION: 6.4.x-snapshot-2026-06-03-a
   WASMTIME_VERSION: 45.0.0
 permissions: {}
 defaults:
@@ -17,9 +17,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a/swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a_wasm.artifactbundle.tar.gz
-              checksum: c5f668a6cfff73a6aef9d00f8ae657de356bef55b13218f52794c02b81805605
-              id: swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a_wasm
+              url: https://download.swift.org/swift-6.4.x-branch/wasm-sdk/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-03-a/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-03-a_wasm.artifactbundle.tar.gz
+              checksum: b740040505211ba11159b79013637d10322c31532ae7424e4c5c6b7ad10a8734
+              id: swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-03-a_wasm
             artifact-name: swift-format.wasm
             other-wasmopt-flags:
     runs-on: ubuntu-24.04-arm
@@ -81,9 +81,9 @@ jobs:
       matrix:
         target:
           - sdk:
-              url: https://download.swift.org/development/wasm-sdk/swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a/swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a_wasm.artifactbundle.tar.gz
-              checksum: c5f668a6cfff73a6aef9d00f8ae657de356bef55b13218f52794c02b81805605
-              id: swift-DEVELOPMENT-SNAPSHOT-2026-03-16-a_wasm
+              url: https://download.swift.org/swift-6.4.x-branch/wasm-sdk/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-03-a/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-03-a_wasm.artifactbundle.tar.gz
+              checksum: b740040505211ba11159b79013637d10322c31532ae7424e4c5c6b7ad10a8734
+              id: swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-06-03-a_wasm
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read


### PR DESCRIPTION
https://github.com/swiftlang/swift-org-website/commit/b1b24d456c0cc020e2a306cd406631756eb92c0a