### PR TITLE
ci: bump wasmtime to 46.0.0

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -6,7 +6,7 @@ on:
     branches: ["wasm32-wasi-release/6.4.x"]
 env:
   SWIFT_VERSION: 6.4.x-snapshot-2026-06-11
-  WASMTIME_VERSION: 45.0.2
+  WASMTIME_VERSION: 46.0.0
 permissions: {}
 defaults:
   run:


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v46.0.0