### PR TITLE
test(wasi): enable absolute symlink tests

### DIFF
--- a/.github/workflows/swiftwasm.yml
+++ b/.github/workflows/swiftwasm.yml
@@ -6,7 +6,6 @@ on:
     branches: ["wasm32-wasi-release/6.4.x"]
 env:
   SWIFT_VERSION: 6.4.x-snapshot-2026-07-15
-  WASMTIME_VERSION: 46.0.1
 permissions: {}
 defaults:
   run:
@@ -91,11 +90,7 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
       - run: ./.github/scripts/ci-install-swiftly.sh
       - run: swiftly install -y --use "$SWIFT_VERSION"
-      - uses: bytecodealliance/actions/wasmtime/setup@6aecabac1eb1dcf7ed94ba9471974415ee2ebef2  # v1.1.2
-        with:
-          version: ${{ env.WASMTIME_VERSION }}
       - run: swift --version
-      - run: wasmtime -V
       - env:
           SDK_URL: ${{ matrix.target.sdk.url }}
           SDK_CHECKSUM: ${{ matrix.target.sdk.checksum }}

--- a/Tests/SwiftFormatTests/Utilities/FileIteratorTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/FileIteratorTests.swift
@@ -54,19 +54,13 @@ final class FileIteratorTests: XCTestCase {
     try touch("project/real2.swift")
     try touch("project/.hidden.swift")
     try touch("project/.build/generated.swift")
-    #if !os(WASI)  // FIXME: Remove this #if
     try symlink("project/link.swift", to: "project/.hidden.swift")
-    #endif
     try symlink("project/rellink.swift", relativeTo: ".hidden.swift")
 
     #if !(os(Windows) && compiler(<5.10))
     // Test both a self-cycle and a cycle between multiple symlinks.
     try symlink("project/cycliclink.swift", relativeTo: "cycliclink.swift")
-    #if !os(WASI)
     try symlink("project/linktolink.swift", relativeTo: "link.swift")
-    #else
-    try symlink("project/linktolink.swift", relativeTo: "rellink.swift")
-    #endif
 
     // Test symlinks that use nonstandardized paths.
     try symlink("project/2stepcyclebegin.swift", relativeTo: "../project/2stepcycleend.swift")
@@ -121,7 +115,6 @@ final class FileIteratorTests: XCTestCase {
         tmpURL("project/cycliclink.swift"),
         tmpURL("project/2stepcyclebegin.swift"),
         tmpURL("project/link.swift"),
-        tmpURL("project/rellink.swift"),
       ],
       followSymlinks: true
     )

--- a/Tests/SwiftFormatTests/Utilities/IgnoreEdgeCaseTests.swift
+++ b/Tests/SwiftFormatTests/Utilities/IgnoreEdgeCaseTests.swift
@@ -158,14 +158,7 @@ struct IgnoreEdgeCaseTests {
 
       // Create a symlink to the real file
       let symlinkFile = testDir.appendingPathComponent("SymlinkFile.swift")
-      #if os(WASI)
-      try FileManager.default.createSymbolicLink(
-        atPath: symlinkFile.path(percentEncoded: false),
-        withDestinationPath: "RealFile.swift"
-      )
-      #else
       try FileManager.default.createSymbolicLink(at: symlinkFile, withDestinationURL: realFile)
-      #endif
 
       // Create ignore file that ignores symlinks
       let ignoreFile = testDir.appendingPathComponent(".swift-format-ignore")

--- a/wasi-test-toolset.json
+++ b/wasi-test-toolset.json
@@ -3,8 +3,9 @@
     "testRunner": {
         "path": "/usr/bin/env",
         "extraCLIOptions": [
-            "wasmtime",
+            "wasmkit",
             "run",
+            "--dir", ".build",
             "--dir", "/"
         ]
     }


### PR DESCRIPTION
Cherry-pick #97 into branch `wasm32-wasi-release/6.4.x`

6.4.x-snapshot now includes WasmKit 0.3.1 that supports absolute symlinks.